### PR TITLE
Fix startup bug due to missing migration files

### DIFF
--- a/aoc_cli.gemspec
+++ b/aoc_cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.bindir = "exe"
   spec.executables = ["aoc"]
-  spec.require_paths = ["lib"]
+  spec.require_paths = %w[lib db]
 
   spec.add_dependency "http"
   spec.add_dependency "kangaru"

--- a/lib/aoc_cli.rb
+++ b/lib/aoc_cli.rb
@@ -14,9 +14,13 @@ module AocCli
   config_path "spec/aoc.yml", env: :test
 
   configure do |config|
+    migration_path = File.join(
+      File.expand_path(__dir__ || raise), "../db/migrate"
+    )
+
     config.database.adaptor = :sqlite
     config.database.path = File.expand_path("~/.local/share/aoc/aoc.sqlite3")
-    config.database.migration_path = "db/migrate"
+    config.database.migration_path = migration_path
   end
 
   configure env: :test do |config|


### PR DESCRIPTION
- Fixes start up bug due to not being able to find db migration files
- This is due to configuration using a relative file path, and the db directory not being bundle in with gem package
